### PR TITLE
Fix modal labelling, modify spectrogram and modal GUI's

### DIFF
--- a/renderer/pages/verify.module.css
+++ b/renderer/pages/verify.module.css
@@ -22,7 +22,6 @@
 	margin-bottom: 0px 20px; 
 }
 
-
 .smallContainerRow {
 	flex: 1; 
 	display: flex; 
@@ -180,4 +179,21 @@
 	padding: 2px 6px;
 	border-radius: 4px;
 	pointer-events: none; /* don't interfere with clicks */
+}
+
+
+/* Added new class for species overlay */
+.speciesOverlay {
+	position: absolute;
+	top: 4px;
+	right: 6px;
+	color: white;
+	font-size: 14px;
+	font-weight: bold;
+	z-index: 10;
+	background-color: rgba(0, 0, 0, 0.6);
+	padding: 2px 6px;
+	border-radius: 4px;
+	pointer-events: none;
+	max-width: 90%;
 }

--- a/renderer/pages/verify.tsx
+++ b/renderer/pages/verify.tsx
@@ -367,9 +367,9 @@ export default function VerifyPage() {
 				style={{ position: "relative" }}
 			>
 				{id!=-1 && <div className={styles.indexOverlay}>{fullIndex+1}</div>}
-				{species && (
-					<div className={styles.speciesOverlay}>{species}</div>
-				)}
+    			<div className={styles.speciesOverlay} style={{ opacity: species ? 1 : 0 }}>
+      				{species || "No label"}
+    			</div>
 				<div id={`loading-spinner-${id}`} className={styles.waveLoadingCircle}></div>
 				<div 
 					id={`waveform-${id}`} 


### PR DESCRIPTION
- Fixed bug with modal label saving (open modal with "o", and press "ENTER" to update label with modal GUI, or press "SHIFT" while spectrogram is selected and "ENTER" to save)
- Updated GUI for modal and general views to display id and label  
- Working on alternate, less intrusive GUI with transparency on labels or labels above spectrograms

![image](https://github.com/user-attachments/assets/23b4bc90-71a4-4b5b-8994-5327a902efc3)
![image](https://github.com/user-attachments/assets/cfc828b3-9b4f-40b1-bd5c-f70442efdb75)
